### PR TITLE
[04주차] 배성훈

### DIFF
--- a/seonghoon/week04(22.01.18~22.01.24)/p42583.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p42583.py
@@ -1,0 +1,32 @@
+from collections import deque
+from typing import Deque, List, Tuple
+
+
+def solution(bridge_length: int, weight: int, truck_weights: List[int]) -> int:
+    prev: int = 1
+    total: int = 0
+    que: Deque[Tuple[int, int]] = deque()
+
+    for tweight in truck_weights:
+        while tweight + total > weight or len(que) >= bridge_length:
+            prev, prev_weight = que.popleft()
+            total -= prev_weight
+
+        passed_time: int = prev + bridge_length
+        if que:
+            passed_time = max(que[-1][0] + 1, passed_time)
+
+        total += tweight
+        que.append((passed_time, tweight))
+
+    return que[-1][0]
+
+
+# 8
+print(solution(2, 10, [7, 4, 5, 6]))
+# 101
+print(solution(100, 100, [10]))
+# 110
+print(solution(100, 100, [10, 10, 10, 10, 10, 10, 10, 10, 10, 10]))
+# 6
+print(solution(1, 10, [1, 2, 3, 7, 8]))

--- a/seonghoon/week04(22.01.18~22.01.24)/p42889.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p42889.py
@@ -1,0 +1,26 @@
+from collections import Counter
+from typing import Dict, List, Tuple
+
+
+def solution(N: int, stages: List[int]) -> List[int]:
+    counter: Counter[int] = Counter(stages)
+    user: int = len(stages)
+
+    failure_rates: Dict[int, float] = {stage: 0 for stage in range(1, N + 1)}
+    for stage in range(1, N + 1):
+        if user <= 0:
+            break
+        failure_rates[stage] = counter[stage] / user
+        user -= counter[stage]
+
+    sorted_rates: List[Tuple[int, float]] = sorted(
+        failure_rates.items(), key=lambda x: (-x[1], x[0])
+    )
+
+    return list(map(lambda x: x[0], sorted_rates))
+
+
+# [3,4,2,1,5]
+print(solution(5, [2, 1, 2, 6, 2, 4, 3, 3]))
+# [4,1,2,3]
+print(solution(4, [4, 4, 4, 4, 4]))

--- a/seonghoon/week04(22.01.18~22.01.24)/p43163.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p43163.py
@@ -1,0 +1,39 @@
+from collections import deque
+from typing import Deque, List, Set, Tuple
+
+
+def can_transform(source: str, target: str) -> bool:
+    diff: int = 0
+    for schar, tchar in zip(source, target):
+        if schar != tchar:
+            diff += 1
+    return diff == 1
+
+
+def solution(begin: str, target: str, words: List[str]) -> int:
+    answer: int = 0
+    que: Deque[Tuple[str, int, Set[str]]] = deque()
+
+    que.append((begin, 0, set([begin])))
+
+    while que:
+        word, stage, visited = que.popleft()
+
+        for cand in words:
+            if cand in visited:
+                continue
+            if not can_transform(word, cand):
+                continue
+
+            if cand == target:
+                return stage + 1
+
+            que.append((cand, stage + 1, visited | set([cand])))
+
+    return answer
+
+
+# 4
+print(solution("hit", "cog", ["hot", "dot", "dog", "lot", "log", "cog"]))
+# 0
+print(solution("hit", "cog", ["hot", "dot", "dog", "lot", "log"]))

--- a/seonghoon/week04(22.01.18~22.01.24)/p43164.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p43164.py
@@ -1,0 +1,49 @@
+from collections import defaultdict, deque
+from typing import DefaultDict, Deque, List, Set, Tuple
+
+
+TicketDict = DefaultDict[str, List[Tuple[int, str]]]
+
+
+def get_next_airports(tickets: List[List[str]]) -> TicketDict:
+    next_airports: TicketDict = defaultdict(list)
+
+    for idx, (start, dest) in enumerate(sorted(tickets, key=lambda x: x[1])):
+        next_airports[start].append((idx, dest))
+
+    return next_airports
+
+
+def solution(tickets: List[List[str]]) -> List[str]:
+    numoftickets: int = len(tickets)
+    next_airports: TicketDict = get_next_airports(tickets)
+
+    que: Deque[Tuple[List[str], Set[int]]] = deque()
+
+    que.append((["ICN"], set()))
+
+    while que:
+        paths, used = que.popleft()
+
+        for tid, next_ in next_airports[paths[-1]]:
+            if tid in used:
+                continue
+
+            next_paths: List[str] = paths + [next_]
+
+            if len(next_paths) == numoftickets + 1:
+                return next_paths
+
+            que.append((next_paths, used | set([tid])))
+
+    return []
+
+
+# ["ICN", "JFK", "HND", "IAD"]
+print(solution([["ICN", "JFK"], ["HND", "IAD"], ["JFK", "HND"]]))
+# ["ICN", "ATL", "ICN", "SFO", "ATL", "SFO"]
+print(
+    solution(
+        [["ICN", "SFO"], ["ICN", "ATL"], ["SFO", "ATL"], ["ATL", "ICN"], ["ATL", "SFO"]]
+    )
+)

--- a/seonghoon/week04(22.01.18~22.01.24)/p49994.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p49994.py
@@ -1,0 +1,34 @@
+from typing import Set, Tuple
+
+
+MOVES = {"U": (1, 0), "D": (-1, 0), "R": (0, 1), "L": (0, -1)}
+
+
+def isrange(y: int, x: int) -> bool:
+    return -5 <= y <= 5 and -5 <= x <= 5
+
+
+def solution(dirs: str) -> int:
+    cury: int = 0
+    curx: int = 0
+    paths: Set[Tuple[int, int, int, int]] = set()
+
+    for dir in dirs:
+        movey, movex = MOVES[dir]
+        nexty: int = cury + movey
+        nextx: int = curx + movex
+
+        if not isrange(nexty, nextx):
+            continue
+
+        paths.add((cury, curx, nexty, nextx))
+        paths.add((nexty, nextx, cury, curx))
+        cury, curx = nexty, nextx
+
+    return len(paths) // 2
+
+
+# 7
+print(solution("ULURRDLLU"))
+# 7
+print(solution("LULLLLLLU"))

--- a/seonghoon/week04(22.01.18~22.01.24)/p67257.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p67257.py
@@ -1,0 +1,24 @@
+from itertools import permutations
+from typing import List
+
+
+def calculate(expression: str, ops: List[str]) -> int:
+    if expression.isdigit():
+        return int(expression)
+
+    curop, nextops = ops[0], ops[1:]
+    splitted: List[int] = [calculate(exp, nextops) for exp in expression.split(curop)]
+    return eval(f"{curop}".join(map(str, splitted)))
+
+
+def solution(expression: str):
+    answer: int = 0
+    for perm in permutations(["+", "-", "*"]):
+        answer = max(answer, abs(calculate(expression, list(perm))))
+    return answer
+
+
+# 60420
+print(solution("100-200*300-500+20"))
+# 300
+print(solution("50*6-3*2"))

--- a/seonghoon/week04(22.01.18~22.01.24)/p77485.py
+++ b/seonghoon/week04(22.01.18~22.01.24)/p77485.py
@@ -1,0 +1,44 @@
+from typing import List
+
+
+board: List[List[int]]
+
+
+def turn(x1: int, y1: int, x2: int, y2: int) -> int:
+    value: int = board[x1][y1]
+    min_value: int = value
+
+    for ridx in range(x1, x2):
+        board[ridx][y1] = board[ridx + 1][y1]
+        min_value = min(min_value, board[ridx][y1])
+
+    for cidx in range(y1, y2):
+        board[x2][cidx] = board[x2][cidx + 1]
+        min_value = min(min_value, board[x2][cidx])
+
+    for ridx in range(x2, x1, -1):
+        board[ridx][y2] = board[ridx - 1][y2]
+        min_value = min(min_value, board[ridx][y2])
+
+    for cidx in range(y2, y1, -1):
+        board[x1][cidx] = board[x1][cidx - 1]
+        min_value = min(min_value, board[x1][cidx])
+
+    board[x1][y1 + 1] = value
+
+    return min_value
+
+
+def solution(rows: int, columns: int, queries: List[List[int]]) -> List[int]:
+    global board
+    board = [[row * columns + col + 1 for col in range(columns)] for row in range(rows)]
+
+    return [turn(x1 - 1, y1 - 1, x2 - 1, y2 - 1) for x1, y1, x2, y2 in queries]
+
+
+# [8, 10, 25]
+print(solution(6, 6, [[2, 2, 5, 4], [3, 3, 6, 6], [5, 1, 6, 3]]))
+# [1, 1, 5, 3]
+print(solution(3, 3, [[1, 1, 2, 2], [1, 2, 2, 3], [2, 1, 3, 2], [2, 2, 3, 3]]))
+# [1]
+print(solution(100, 97, [[1, 1, 100, 97]]))


### PR DESCRIPTION
## 142889 - 실패율

> https://programmers.co.kr/learn/courses/30/lessons/42889

### 아이디어

### 풀이방법

각 스테이지별로 도전 중인 사용자의 수를 세고, 도전한 사용자는 전체 사용자에서 이전 스테이지까지 도전한 사용자의 수를 빼서 구합니다. 두 수치를 알면 실패율을 구할 수 있고, 이를 정렬해 답을 구합니다.

---

## 43163 - 단어 변환

> https://programmers.co.kr/learn/courses/30/lessons/43163

### 아이디어

### 풀이방법

bfs로 변환까지 걸리는 과정을 세어줍니다. 단어가 변환 가능한지는 단어를 알파벳단위로 비교하며 다른 알파벳의 개수가 1개일 때 변환 가능하다고 판단해줍니다.

---

## 43164 - 여행경로

> https://programmers.co.kr/learn/courses/30/lessons/43164

### 아이디어

### 풀이방법

bfs로 가능한 경로를 살펴보다가 `경로상 공항의 개수 == 티켓 개수 + 1`이 되는 시점이 여행경로입니다.

---

## 49994 - 방문 길이

> https://programmers.co.kr/learn/courses/30/lessons/49994

### 아이디어

경로를 (시작점, 끝점), (끝점, 시작점)으로 set에 저장

### 풀이방법

캐릭터가 이동할 때 경로를 set에 넣습니다. 이때, (시작점, 끝점)과 (끝점, 시작점) 두 경우를 모두 넣어 같은 경로를 반대 방향으로 걸었을 때를 고려해줍니다. 최종적으로 경로의 개수는 set의 원소 개수 / 2입니다.

---

## 67257 - 수식 최대화

> https://programmers.co.kr/learn/courses/30/lessons/67257

### 아이디어

`join()`과 `eval()`을 이용하여 재귀로 계산한 값을 합쳐줍니다.

### 풀이방법

가능한 모든 연산자 조합을 구하고, `calculate()` 함수를 통해 계산합니다. `calculate()` 함수는 표현식을 현재 계산해야 하는 연산자를 기준으로 자르고, 잘린 값들을 재귀적으로 계산한 후, `join()`과 `eval()` 함수를 통해 최종적으로 계산합니다.

---

## 42583 - 다리를 지나는 트럭

> https://programmers.co.kr/learn/courses/30/lessons/42583

### 아이디어

`que`에 다리를 지나가고 있는 트럭과 트럭이 지나갔을 때의 시간을 저장합니다.

### 풀이방법

다리를 다 지난 트럭이나 무게로 인해 지날 때까지 기다려야 하는 트럭을 큐에서 제거합니다. 대기 트럭을 큐에 넣을 때, 해당 트럭이 다리를 지나갔을 때 시간을 저장하는데 이 시간은 `마지막으로 지나간 트럭 + 다리 길이` 또는 `지금 지나고 있는 마지막 트럭의 시간 + 1` 중 더 큰 값이 됩니다.

---

## 77485 - 행렬 테두리 회전하기

> https://programmers.co.kr/learn/courses/30/lessons/77485

### 아이디어

### 풀이방법

for문을 4번 돌려 회전시켜줍니다.
