### PR TITLE
[04주차] 박현준

### DIFF
--- a/hyeonjun/4week/p42583.py
+++ b/hyeonjun/4week/p42583.py
@@ -1,0 +1,18 @@
+from collections import deque
+
+
+def solution(bridge_length, weight, truck_weights):
+    answer = 0
+    queue = deque([0 for _ in range(bridge_length)])
+    now_weight = 0
+    while queue:
+        answer += 1
+        now_weight -= queue.popleft()
+        if truck_weights:
+            if now_weight + truck_weights[0] <= weight:
+                truck = truck_weights.pop(0)
+                queue.append(truck)
+                now_weight += truck
+            else:
+                queue.append(0)
+    return answer

--- a/hyeonjun/4week/p42889.py
+++ b/hyeonjun/4week/p42889.py
@@ -1,0 +1,19 @@
+def solution(N, stages):
+    answer = {}
+    # [스테이지에 도달했으나 아직 클리어하지 못한 플레이어의 수, 스테이지에 도달한 플레이어의 수, 스테이지 번호]
+    failure_count = [[0, 0, (i+1)] for i in range(N)]
+    stages.sort(reverse=True)
+
+    for idx, stage in enumerate(stages):
+        if stage > N:
+            continue
+        failure_count[stage-1][0] += 1
+        failure_count[stage-1][1] = idx+1
+
+    for stage in failure_count:
+        if not stage[1]:  # avoid ZeroDivisionError
+            answer[stage[2]] = 0
+        else:
+            answer[stage[2]] = stage[0]/stage[1]
+
+    return sorted(answer, key=lambda x: answer[x], reverse=True)

--- a/hyeonjun/4week/p43163.py
+++ b/hyeonjun/4week/p43163.py
@@ -1,0 +1,53 @@
+from collections import deque
+
+
+def bfs(begin, target):
+    queue = deque()
+    queue.append((begin, 0))
+    while queue:
+        letter_idx, cnt = queue.popleft()
+        for word in tree[letter_idx]:
+            if word == target:
+                return cnt+1
+            if not visited[word]:
+                queue.append((word, cnt+1))
+    return 0
+
+
+def compare_words(word1, word2):
+    different_cnt = 0
+    for idx, letter in enumerate(word1):
+        if letter != word2[idx]:
+            different_cnt += 1
+        if different_cnt > 1:
+            return 0
+    return 1
+
+
+def make_tree(words):
+    length = len(words)
+    for i in range(length):
+        for j in range(i+1, length):
+            if compare_words(words[i], words[j]):
+                tree[i].append(j)
+                tree[j].append(i)
+    return 1
+
+
+def solution(begin, target, words):
+    global tree
+    global visited
+
+    if target not in words:
+        return 0
+
+    length = len(words)
+    tree = {i: [] for i in range(length+2)}
+    visited = [0 for _ in range(length+2)]
+
+    words.append(begin)
+    words.append(target)
+
+    make_tree(words)
+
+    return bfs(length, length+1)

--- a/hyeonjun/4week/p43164.py
+++ b/hyeonjun/4week/p43164.py
@@ -1,0 +1,40 @@
+from collections import deque
+
+
+def dfs(airport, route, route_cnt):
+    cnt = 0
+    while cnt < len(bridge[airport]):
+        next_airport = bridge[airport].popleft()
+        route.append(next_airport)
+        route_cnt -= 1
+
+        if not route_cnt:
+            return route
+
+        tmp = dfs(next_airport, route, route_cnt)
+        if tmp:
+            return tmp
+
+        bridge[airport].append(next_airport)
+        route.pop()
+        route_cnt += 1
+        cnt += 1
+
+    return 0
+
+
+def solution(tickets):
+    global bridge
+
+    tickets.sort()
+    airports = set()
+    for ticket in tickets:
+        airports.add(ticket[0])
+        airports.add(ticket[1])
+
+    bridge = {airport: deque() for airport in airports}
+    for ticket in tickets:
+        bridge[ticket[0]].append(ticket[1])
+
+    route_cnt = len(tickets)
+    return dfs('ICN', ['ICN'], route_cnt)

--- a/hyeonjun/4week/p49994.py
+++ b/hyeonjun/4week/p49994.py
@@ -1,0 +1,16 @@
+MOVE = {'U': (-1, 0), 'D': (1, 0), 'L': (0, -1), 'R': (0, 1)}
+
+
+def solution(dirs):
+    location = set()
+    x, y = 0, 0
+    for dir in dirs:
+        dx, dy = MOVE[dir]
+        nx = x + dx
+        ny = y + dy
+        if -5 <= nx <= 5 and -5 <= ny <= 5:
+            location.add((x, y, nx, ny))
+            location.add((nx, ny, x, y))
+            x, y = nx, ny
+
+    return len(location)//2

--- a/hyeonjun/4week/p67257.py
+++ b/hyeonjun/4week/p67257.py
@@ -1,0 +1,32 @@
+import re
+from itertools import permutations
+from copy import deepcopy
+
+
+def calc(arr, target, start):
+    for idx, sign in enumerate(arr[start:]):
+        idx += start
+        if target == sign:
+            arr[idx-1] = eval(
+                str(arr[idx-1]) + sign + str(arr[idx+1]))
+            del arr[idx]
+            del arr[idx]
+            calc(arr, sign, idx-1)
+            return 0
+    return 1
+
+
+def solution(expression):
+    answer = 0
+    signs = set(re.findall('[-+*]', expression))
+    test = re.split('\D', expression)
+
+    signs_comb = permutations(signs, len(signs))
+
+    for order in signs_comb:
+        copy_numbers = deepcopy(test)
+        for target in order:
+            calc(copy_numbers, target, 0)
+        if answer < abs(copy_numbers[0]):
+            answer = abs(copy_numbers[0])
+    return answer

--- a/hyeonjun/4week/p77485.py
+++ b/hyeonjun/4week/p77485.py
@@ -1,0 +1,38 @@
+from collections import deque
+
+
+def rotate(x1, y1, x2, y2, matrix):
+    queue = deque()
+    for i in range(y1-1, y2-1, 1):
+        queue.append(matrix[x1-1][i])
+    for i in range(x1-1, x2-1, 1):
+        queue.append(matrix[i][y2-1])
+    for i in range(y2-1, y1-1, -1):
+        queue.append(matrix[x2-1][i])
+    for i in range(x2-1, x1-1, -1):
+        queue.append(matrix[i][y1-1])
+
+    tmp = min(queue)
+    for i in range(y1, y2, 1):
+        matrix[x1-1][i] = queue.popleft()
+    for i in range(x1, x2, 1):
+        matrix[i][y2-1] = queue.popleft()
+    for i in range(y2-2, y1-2, -1):
+        matrix[x2-1][i] = queue.popleft()
+    for i in range(x2-2, x1-2, -1):
+        matrix[i][y1-1] = queue.popleft()
+    return tmp
+
+
+def solution(rows, columns, queries):
+    answer = []
+    matrix = []
+    for i in range(rows):
+        matrix.append([])
+        for j in range(columns):
+            matrix[i].append((i)*columns+j+1)
+
+    for query in queries:
+        answer.append(rotate(query[0], query[1], query[2], query[3], matrix))
+
+    return answer


### PR DESCRIPTION
**p42889 - 실패율**

- [스테이지에 도달했으나 아직 클라어하지 못한 플레이어의 수, 스테이지에 도달한 플레이어의 수, 스테이지 번호]인 `failure_count` 배열을 생성한다.
- 주어진 `stages`를 내림차순으로 정렬한다.
- 정렬된 `stages`를 앞에서부터 탐색하면, 스테이지에 도달했으나 아직 클리어하지 못한 플레이어의 수는 해당 스테이지가 탐색될 때마다 1씩 더해지고, 스테이지에 도달한 플레이어의 수는 해당 스테이지가 마지막에 탐색될 때의 `index+1`과 같다.
- 위에서 수행된 `failure_count` 배열의 각 항을 스테이지에 도달했으나 아직 클리어하지 못한 플레이어의 수를 스테이지에 도달한 플레이어의 수로 나누고 모든 결과를 정렬한다..

**p43163 - 단어 변환**

- 각각의 단어와 한 글자만 다른 글자들을 딕셔너리에 저장한다. 저장할 때, 각각의 단어는 문자열 대신 고유번호를 지정하여 저장한다. ex) {hot: lot,dot} -> {0: 1,3}
- bfs로 딕셔너리를 탐색하여 `begin`에서 `target`으로 변형되는 최단 거리를 구한다.

**p43164 - 여행경로**

- 각각의 공항에서 갈 수 있는 모든 공항을 사전 순서대로 `bridge` 딕셔너리에 저장한다.
- `bridge`를 dfs로 탐색하여 모든 도시를 방문할 수 있는 경로를 구한다.

**p49994 - 방문 길이**

- set자료구조에 지나간 모든 길의 시작점+끝점을 저장한다. ex) .add((x,y,nx,ny))
- set자료구조의 길이의 절반이 답이 된다.

**p67257 - 수식 최대화**

- 정규표현식을 이용하여 `expression`을 숫자와 기호를 구분하여 `test`로 정의한다. ex) test -> ['200', '+', '30']
- 사용되는 기호로 만들 수 있는 모든 조합을 미리 만들고, 모든 경우에 `expression`을 대입해본다.
- `test`에 재귀와 `del`을 사용해서 모든 경우의 해답을 구하고, 그 중 가장 큰 값을 답으로 정한다. ex) ['200', '+', '30', '*', '5'] -> calculate & using `del` -> ['200', '+', '600'] -> calculate & using `del` -> ...

**p42584 - 다리를 지나는 트럭**

- 다리 길이만큼의 길이를 가지는 `queue`를 생성하고, 현재 다리가 부담하고 있는 무게를 나타내는 `now_weight`를 0으로 정의한다.
- `truck_weights`에서 순서대로 트럭들을 확인하면서, 다리에 여유무게가 있다면 `queue`에 트럭을 추가하고, 아니라면 0을 추가하면서 시간을 경과시킨다.
- queue가 빌 때까지, 반복한다.

**p77485 - 행렬 테두리 회전하기**

- 시작점을 지정하여 회전하는 순서대로 큐에 번호를 넣는다.
- 시작점 바로 다음 칸부터 큐에 넣은 순서대로 번호를 빼서 행렬에 입력한다.
