### PR TITLE
[12주차] 박현준

### DIFF
--- a/hyeonjun/12week/16637.py
+++ b/hyeonjun/12week/16637.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+if __name__ == '__main__':
+
+    def cut(idx, res, sym):
+        global ans
+        if idx >= N:
+            ans = max(ans, int(res))
+            return 0
+
+        tmp = '+'
+        if idx+3 < N:
+            tmp = exp[idx+3]
+        cut(idx+4, str(eval(res+sym + str(eval(exp[idx:idx+3])))), tmp)
+        cut(idx+2, str(eval(res+sym+exp[idx])), exp[idx+1])
+
+    ans = float('-inf')
+    N = int(input())
+    exp = input()
+    cut(0, '0', '+')
+    print(ans)

--- a/hyeonjun/12week/2011.py
+++ b/hyeonjun/12week/2011.py
@@ -1,0 +1,19 @@
+import sys
+input = sys.stdin.readline
+
+if __name__ == "__main__":
+    password = str(input().rstrip())
+
+    if not password:
+        print(0)
+        exit()
+
+    dp = [[0, 0] for _ in range(len(password))]
+    if int(password[0]):
+        dp[0][0] = 1
+    for i in range(len(password)-1):
+        if int(password[i+1]):
+            dp[i+1][0] = dp[i][0] + dp[i][1]
+        if int(password[i:i+2]) < 27:
+            dp[i+1][1] = dp[i][0]
+    print(sum(dp[-1]) % 1000000)

--- a/hyeonjun/12week/5569.py
+++ b/hyeonjun/12week/5569.py
@@ -1,0 +1,17 @@
+import sys
+input = sys.stdin.readline
+
+if __name__ == '__main__':
+    w, h = map(int, input().split())
+    dp = [[[0 for _ in range(4)] for _ in range(w)]for _ in range(h)]
+
+    for i in range(w-1):
+        dp[0][i+1][1] = 1
+    for i in range(h-1):
+        dp[i+1][0][0] = 1
+
+    for i in range(h-1):
+        for j in range(w-1):
+            dp[i+1][j+1] = [dp[i][j+1][2]+dp[i][j+1][0], dp[i+1]
+                            [j][3] + dp[i+1][j][1],  dp[i][j+1][1], dp[i+1][j][0]]
+    print(sum(dp[-1][-1]) % 100000)

--- a/hyeonjun/12week/Jump_Game.py
+++ b/hyeonjun/12week/Jump_Game.py
@@ -1,0 +1,10 @@
+class Solution:
+    def canJump(self, nums: List[int]) -> bool:
+        length = len(nums)
+        target = length - 1
+        for index in range(length - 2, -1, -1):
+            step = nums[index]
+            if index + step >= target:
+                target = index
+
+        return True if not target else False

--- a/hyeonjun/12week/p72413.py
+++ b/hyeonjun/12week/p72413.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+
+
+def solution(n, s, a, b, fares):
+    def floyd_warshall():
+        dist = [[float('inf') for _ in range(n+1)] for _ in range(n+1)]
+        for i in range(1, n+1):
+            for j in range(1, n+1):
+                if graph[i][j] or i == j:
+                    dist[i][j] = graph[i][j]
+        for k in range(1, n+1):
+            for i in range(1, n+1):
+                for j in range(1, n+1):
+                    if dist[i][j] > dist[i][k] + dist[k][j]:
+                        dist[i][j] = dist[i][k] + dist[k][j]
+        return dist
+
+    graph = {i: defaultdict(int) for i in range(1, n+1)}
+    for node1, node2, fee in fares:
+        graph[node1][node2] = fee
+        graph[node2][node1] = fee
+    dist = floyd_warshall()
+
+    answer = dist[s][a] + dist[s][b]
+    for node in range(1, n+1):
+        answer = min(answer, dist[s][node] + dist[node][a] + dist[node][b])
+
+    return answer

--- a/hyeonjun/12week/p87391.py
+++ b/hyeonjun/12week/p87391.py
@@ -1,0 +1,30 @@
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+
+def solution(n, m, x, y, queries):
+    lx, rx, ly, ry = x, x+1, y, y+1
+    for idx, dist in queries[::-1]:
+        if idx == 0 and ly == 0:
+            ry += dist
+        elif idx == 1 and ry == m:
+            ly -= dist
+        elif idx == 2 and lx == 0:
+            rx += dist
+        elif idx == 3 and rx == n:
+            lx -= dist
+        else:
+            lx += dx[idx]*dist
+            ly += dy[idx]*dist
+            rx += dx[idx]*dist
+            ry += dy[idx]*dist
+
+        if lx > n - 1 or rx < 0 or ly > m - 1 or ry < 0:
+            return 0
+
+        lx = max(0, lx)
+        ly = max(0, ly)
+        rx = min(n, rx)
+        ry = min(m, ry)
+
+    return (rx-lx)*(ry-ly)

--- a/hyeonjun/12week/search_a_2D_matrix.py
+++ b/hyeonjun/12week/search_a_2D_matrix.py
@@ -1,0 +1,21 @@
+class Solution:
+    def searchMatrix(self, matrix: List[List[int]], target: int) -> bool:
+        def binary_search(matrix: List[int], target: int) -> int:
+            start = 0
+            end = len(matrix) - 1
+            mid = (start+end) // 2
+
+            while start <= end:
+                if matrix[mid] == target:
+                    return mid
+                elif matrix[mid] < target:
+                    start = mid + 1
+                else:
+                    end = mid - 1
+                mid = (start+end)//2
+
+            return mid
+
+        first_column = [row[0] for row in matrix]
+        cand_row = matrix[binary_search(first_column, target)]
+        return True if target == cand_row[binary_search(cand_row, target)] else False


### PR DESCRIPTION
**합승 택시 요금 - p72413**

- 플로이드 와샬 알고리즘을 이용해 최단 거리 배열을 생성한다.
- 각각의 노드를 포함하는 경로를 탐색하여 최소 요금을 구한다.

**공 이동 시뮬레이션 - p87391**

- 그냥 구현하면 시간초과가 나서 힌트를 살짝 보고 진행했습니다.
- 포인트는 도착지를 점이 아닌 면적으로 본다는 것과 쿼리 역순으로 진행한다는 점입니다.
- 1. ```x,y```를 왼쪽윗점, 오른쪽아랫점으로 면적으로 치환합니다. x,y = (0,0) -> lx,ly = (0,0), rx,ry = (1,1)
- 2. 역순이란 점을 잘 생각해보면, 퀴리가 지시하는 반댓방향으로 면적좌표를 옮겨야 함을 알 수 있습니다.
- 3. 하지만, 퀴리가 지시하는 방향이 벽으로 막혀있을 경우, 면적좌표를 옮기는 것이 아닌 반대방향으로 면적을 확장해야 합니다.
- 4. 이렇게 이동과 확장을 진행하는 과정에서 쿼리가 지시하는 반댓방향으로 좌표가 튀어나갈 경우, ```answer```가 0이라는 조건을 넣어야 합니다.
- 5. 이렇게 최종면적을 구하게 되면 면적의 넓이가 답이 됩니다.


**암호 코드 - 2011**

- 탐색할 차례인 수가 0이 아닌 경우,
- dp[i+1][0] = dp[i][0] + dp[i][1]
- 연속된 두 수가 26이하일 경우,
- dp[i+1][1] = dp[i][0]
- 답 : sum(dp[-1])

**출근 경로 - 5569**

- dp.
- [종으로 꺾는 경우, 횡의로 꺾는 경우, 종으로 진행하는 경우, 횡으로 진행하는 경우]

**괄호 추가하기 - 16637**

- 첫 숫자부터 차례대로 해당 숫자부터 괄호를 시작하는 경우, 괄호를 사용하지 않는 경우. 두 가지로 나누어 모든 경우의 수를 탐색한다.

**Jump_Game**

- 0번 인덱스부터 점프할 수 있는 가장 먼 곳부터 가까운 곳까지 재귀를 통해 반복하며 탐색. -> 약 9000ms
- 마지막 인덱스부터 0번 인덱스 순으로 (인덱스+점프 가능한 거리)가 `target`값 즉, 마지막 인덱스에 도달할 수 있는 최소 인덱스값보다 큰 지 확인하며 `target`값을 갱신해주며 탐색 -> 약 600ms

**search a 2D matrix**

- 1열을 이분탐색하여 `target`이 속해 있는 행을 찾는다.
- 해당 행을 이분탐색하여 `target`이 포함되어 있는 지 판별한다.
