### PR TITLE
[13주차] 박현준

### DIFF
--- a/hyeonjun/13week/1063.py
+++ b/hyeonjun/13week/1063.py
@@ -1,0 +1,29 @@
+import sys
+input = sys.stdin.readline
+
+dx = {'R': 1, 'L': -1, 'B': 0, 'T': 0, 'RT': 1, 'LT': -1, 'RB': 1, 'LB': -1}
+dy = {'R': 0, 'L': 0, 'B': -1, 'T': 1, 'RT': 1, 'LT': 1, 'RB': -1, 'LB': -1}
+
+if __name__ == "__main__":
+    king, pawn, n = map(str, input().split())
+    orders = [str(input().rstrip()) for _ in range(int(n))]
+    king_x, king_y = ord(king[0])-64, int(king[1])
+    pawn_x, pawn_y = ord(pawn[0])-64, int(pawn[1])
+
+    for order in orders:
+        nx = king_x + dx[order]
+        ny = king_y + dy[order]
+        if nx < 1 or nx > 8 or ny < 1 or ny > 8:
+            continue
+        if nx == pawn_x and ny == pawn_y:
+            p_nx = pawn_x + dx[order]
+            p_ny = pawn_y + dy[order]
+            if p_nx < 1 or p_nx > 8 or p_ny < 1 or p_ny > 8:
+                continue
+            king_x, king_y = nx, ny
+            pawn_x, pawn_y = p_nx, p_ny
+        else:
+            king_x, king_y = nx, ny
+
+    print(chr(king_x+64)+str(king_y))
+    print(chr(pawn_x+64)+str(pawn_y))

--- a/hyeonjun/13week/15898.py
+++ b/hyeonjun/13week/15898.py
@@ -1,0 +1,80 @@
+import sys
+from itertools import permutations
+from copy import deepcopy
+input = sys.stdin.readline
+
+color_to_cnt = {'R': 7, 'B': 5, 'G': 3, 'Y': 2, 'W': 0}
+
+
+def calculate(target):
+    global answer
+    cnt = 0
+    for i in range(5):
+        for j in range(5):
+            cnt += target[i][j][0]*target[i][j][1]
+    answer = max(answer, cnt)
+    return 0
+
+
+def put(x, y, target, idx, kiln):
+    copy_klin = deepcopy(kiln)
+    for i in range(4):
+        for j in range(4):
+            add_num = copy_klin[x+i][y+j][0] + target[idx][i][j][0]
+            copy_klin[x+i][y+j][0] = min(max(0, add_num), 9)
+            if target[idx][i][j][1]:
+                copy_klin[x+i][y+j][1] = target[idx][i][j][1]
+    return copy_klin
+
+
+def go(kiln, order, idx):
+    if idx == 3:
+        calculate(kiln)
+        return 0
+
+    cand_start = [(0, 0), (1, 0), (0, 1), (1, 1)]
+    for i in range(4):
+        x, y = cand_start[i]
+        go(put(x, y, materials1, order[idx], kiln), order, idx+1)
+        go(put(x, y, materials2, order[idx], kiln), order, idx+1)
+        go(put(x, y, materials3, order[idx], kiln), order, idx+1)
+        go(put(x, y, materials4, order[idx], kiln), order, idx+1)
+
+
+def rotate(material):  # 90도 회전
+    ret = [[0 for _ in range(4)] for _ in range(4)]
+    for i in range(4):
+        for j in range(4):
+            ret[j][3-i] = material[i][j]
+    return ret
+
+
+if __name__ == '__main__':
+    answer = 0
+    n = int(input())
+    kiln = [[[0, 0]for _ in range(5)] for _ in range(5)]
+    materials1 = [[[[0, 0] for _ in range(4)] for _ in range(4)]
+                  for _ in range(n)]
+    materials2 = [[[[0, 0] for _ in range(4)] for _ in range(4)]
+                  for _ in range(n)]
+    materials3 = [[[[0, 0] for _ in range(4)] for _ in range(4)]
+                  for _ in range(n)]
+    materials4 = [[[[0, 0] for _ in range(4)] for _ in range(4)]
+                  for _ in range(n)]
+    for i in range(n):
+        for j in range(4):
+            nums = list(map(int, input().split()))
+            for k, num in enumerate(nums):
+                materials1[i][j][k][0] = num
+        for j in range(4):
+            colors = list(map(str, input().split()))
+            for k, color in enumerate(colors):
+                materials1[i][j][k][1] = color_to_cnt[color]
+        materials2[i] = rotate(materials1[i])
+        materials3[i] = rotate(materials2[i])
+        materials4[i] = rotate(materials3[i])
+
+    orders = permutations([i for i in range(n)], 3)
+    for order in orders:
+        go(kiln, order, 0)
+    print(answer)

--- a/hyeonjun/13week/2563.py
+++ b/hyeonjun/13week/2563.py
@@ -1,0 +1,13 @@
+import sys
+input = sys.stdin.readline
+
+if __name__ == "__main__":
+    n = int(input())
+    black = set()
+    for _ in range(n):
+        x, y = map(int, input().split())
+        for i in range(x, x+10):
+            for j in range(y, y+10):
+                black.add((i, j))
+
+    print(len(black))

--- a/hyeonjun/13week/68645.py
+++ b/hyeonjun/13week/68645.py
@@ -1,0 +1,35 @@
+def solution(n):
+    answer = []
+    down_right = [[] for _ in range(n)]  # 아래진행 + 우측진행만 저장하는 배열
+    up = [[] for _ in range(n)]  # 위로진행만 저장하는 배열
+
+    ceiling = 0
+    floor = n-1
+    num = 1
+
+    while n:
+        for i in range(n):
+            down_right[ceiling+i].append(num)
+            num += 1
+        ceiling += 2
+        n -= 1
+        if not n:
+            break
+
+        for i in range(n):
+            down_right[floor].append(num)
+            num += 1
+        floor -= 1
+        n -= 1
+        if not n:
+            break
+
+        for i in range(n):
+            up[floor-i].append(num)
+            num += 1
+        n -= 1
+
+    for i in range(len(up)):
+        answer += (down_right[i] + up[i][::-1])
+
+    return answer

--- a/hyeonjun/13week/68936.py
+++ b/hyeonjun/13week/68936.py
@@ -1,0 +1,25 @@
+def solution(arr):
+    answer = [0, 0]
+
+    def check(s_x, s_y, e_x, e_y):
+        flag = arr[s_x][s_y]
+        half = (e_x-s_x+1)//2
+
+        if s_x == e_x:
+            answer[flag] += 1
+            return 0
+
+        for i in range(s_x, e_x+1):
+            for j in range(s_y, e_y+1):
+                if arr[i][j] != flag:
+                    check(s_x, s_y, e_x-half, e_y-half)
+                    check(s_x, s_y+half, e_x-half, e_y)
+                    check(s_x+half, s_y, e_x, e_y-half)
+                    check(s_x+half, s_y+half, e_x, e_y)
+                    return 0
+
+        answer[flag] += 1
+        return 0
+
+    check(0, 0, len(arr)-1, len(arr)-1)
+    return answer

--- a/hyeonjun/13week/p42884.py
+++ b/hyeonjun/13week/p42884.py
@@ -1,0 +1,12 @@
+def solution(routes):
+    answer = 0
+    routes.sort()
+    cctv = -30001
+    for start, end in routes:
+        if start > cctv:
+            answer += 1
+            cctv = end
+        else:
+            if end < cctv:
+                cctv = end
+    return answer

--- a/hyeonjun/13week/p87390.py
+++ b/hyeonjun/13week/p87390.py
@@ -1,0 +1,11 @@
+def solution(n, left, right):
+    arr = []
+    left, right = int(left), int(right)
+    for i in range(left//n+1, right//n+2):
+        for j in range(i, n+1):
+            if j == i:
+                arr += [j for _ in range(j)]
+            else:
+                arr += [j]
+
+    return arr[left % n:] if not (right+1) % n else arr[left % n:len(arr)-(n-(right+1) % n)]


### PR DESCRIPTION
**삼각 달팽이 - p68645**

- 구현. 약 20분.
- `n`이 6이라면 아래로 6칸 우측으로 5칸 위로 4칸 다시 아래로 3칸... 을 0칸이 될 때까지 반복한다.
- 해당 순서에 따라 미리 만들어 놓은 `n`개의 배열 중 해당 층에 숫자를 추가한다.
- 이 때, 규칙에서는 아래,우측,위,아래... 순서지만 위로 가는 모든 숫자들은 가장 마지막에 추가되어야 한다.
- 따라서 아래,우측으로 가는 숫자를 쌓는 배열 하나와 위로 가는 숫자를 쌓는 배열 하나를 따로 생성하여 모든 과정이 끝난 후, 두 배열을 합치면 정답.

**n^2 배열 자르기 - p87390**

- 구현. 약 30분.
- 이차원배열 구현 -> 시간초과
- 일차원배열 구현 -> 시간초과
- 일차원배열 구현(범위 제한) -> 통과
- (1등 풀이 현타옴..)

**쿼드압축 후 개수 세기 - p68936**

- 재귀+구현. 약 15분.
- 구역이 모두 같은 수인지 체크 -> 아니라면 4분할
- 위 과정을 반복하며 해당 수에 1씩 더해주면 정답.

**색종이 - 2563**

- 구현. 약 5분.
- 검은색 종이가 가리는 모든 면적의 좌표를 (x,y)꼴로 `set`에 추가한다.
- `set`의 길이가 정답.

**피아의 아틀리에 - 15898**

- 구현. 예제를 맞추기까지 90분.
- 파이썬으론 시간 제한을 뚫을 수 없는 것 같은 문제. (파이썬으로 맞춘 사람이 없음.)
- 미리 0도, 90도, 180도, 270도가 돌아간 재료의 배열들을 만들어놓고 문제에 맞춰 구현함.

**킹 - 1063**

- 구현. 약 20분.
- 움직임을 나타내는 알파벳을 좌표계로 치환. ex) R -> (1,0)
- 치환된 좌표로 킹을 움직이며 돌과 부딪히는 지 체스판을 벗어나는 지 확인.
- 돌과 부딪히지 않으면 킹만 이동. 돌과 부딪히면 돌을 움직여 체스판을 벗어나는 지 확인.
- 돌도 벗어나지 않는다면 킹과 돌 모두 이동.

**단속카메라 - p42884.py**

- Greedy. 약 15분.

1. `routes`를 정렬하고 현재 cctv값을 -30001로 둔다.
2. `routes`를 순서대로 돌면서, 진입지점이 cctv값보다 크면 answer에 1을 더하고 cctv값을 나간지점으로 바꾼다.
3. 진입지점이 cctv값보다 작거나 같으면서 나간지점도 cctv값보다 작다면 이전 `route`에 포함되어 있다는 뜻이므로, cctv값만 나간지점으로 바꾼다.
