### PR TITLE
[18주차] 박제균

### DIFF
--- a/jekyun-park/week18/boj/10775.py
+++ b/jekyun-park/week18/boj/10775.py
@@ -1,0 +1,27 @@
+import sys
+
+input = sys.stdin.readline
+answer = 0
+g = int(input())
+p = int(input())
+parent = [i for i in range(g + 1)]
+planes = []
+
+for _ in range(p):
+    planes.append(int(input()))
+
+
+def find(x):
+    if parent[x] == x:
+        return x
+    parent[x] = find(parent[x])
+    return parent[x]
+
+
+for plane in planes:
+    p = find(plane)
+    if p == 0:
+        break
+    parent[p] = parent[p - 1]
+    answer += 1
+print(answer)

--- a/jekyun-park/week18/boj/16938.py
+++ b/jekyun-park/week18/boj/16938.py
@@ -1,0 +1,14 @@
+import sys
+from itertools import combinations
+
+
+N, L, R, X = map(int, sys.stdin.readline().split())
+difficulties = list(map(int, sys.stdin.readline().split()))
+result = 0
+for i in range(2, N + 1):
+    for comb in combinations(difficulties, i):
+        if L <= sum(comb) <= R:
+            if max(comb) - min(comb) >= X:
+                result += 1
+
+print(result)

--- a/jekyun-park/week18/boj/b10775.swift
+++ b/jekyun-park/week18/boj/b10775.swift
@@ -1,0 +1,37 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/02.
+//  BOJ > 10775 > 공항
+
+import Foundation
+
+let G = Int(readLine()!)!
+let P = Int(readLine()!)!
+var gates = [Int]()
+var parent = Array(0...G)
+
+func find(_ n: Int) -> Int {
+    if n == parent[n] { return n }
+    return find(parent[n])
+}
+
+func union(_ a: Int, _ b: Int) {
+    parent[a] = parent[b]
+}
+
+var answer = 0
+
+for _ in 0..<P {
+    gates.append(Int(readLine()!)!)
+}
+
+for i in gates {
+    let parent = find(i)
+    if parent == 0 { break }
+    answer += 1
+    union(parent, parent-1)
+}
+
+print(answer)

--- a/jekyun-park/week18/boj/b16938.swift
+++ b/jekyun-park/week18/boj/b16938.swift
@@ -1,0 +1,57 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/04/30.
+//  BOJ > 16938 > 캠프 준비
+
+import Foundation
+
+func combination<T: Comparable>(_ array: [T], _ n: Int) -> [[T]] {
+    var result = [[T]]()
+    if array.count < n { return result }
+
+    var stack = array.enumerated().map { ([$0.element], $0.offset) }
+
+    while stack.count > 0 {
+        let now = stack.removeLast()
+
+        let elements = now.0
+        let index = now.1
+
+        if elements.count == n {
+            result.append(elements.sorted())
+            continue
+        }
+
+        guard index+1 <= array.count-1 else { continue }
+
+        for i in index+1...array.count-1 {
+            stack.append((elements + [array[i]], i))
+        }
+    }
+
+    return result
+}
+
+let NLRX = readLine()!.split(separator: " ").map { Int($0)! }
+let N = NLRX[0], L = NLRX[1], R = NLRX[2], X = NLRX[3]
+let problems = readLine()!.split(separator: " ").map { Int($0)! }
+var difficulty = 0
+var difference = 0
+var answer = 0
+
+for i in 2...N {
+    let cases = combination(problems, i)
+
+    for senario in cases {
+        difficulty = senario.reduce(0,+)
+        difference = senario.max()! - senario.min()!
+        if difficulty < L || difficulty > R { continue }
+        if difference < X { continue }
+        answer += 1
+    }
+    
+}
+
+print(answer)

--- a/jekyun-park/week18/boj/b20040.swift
+++ b/jekyun-park/week18/boj/b20040.swift
@@ -1,0 +1,41 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/01.
+//  BOJ > 20040 > 사이클 게임
+
+import Foundation
+
+let NM = readLine()!.split(separator: " ").map { Int($0)! }
+
+//var graph: [Int:[Int]] = [:]
+var parent = Array(0...NM[0]-1)
+//var visited = Array(repeating: false, count: NM[0])
+
+func union(_ x:Int, _ y:Int) {
+    let parentX = findParent(x)
+    let parentY = findParent(y)
+    if parentX < parentY { parent[parentY] = parentX }
+    else { parent[parentX] = parentY }
+}
+
+func findParent(_ x:Int ) -> Int {
+    if parent[x] == x { return x }
+    return findParent(parent[x])
+}
+
+for i in 1...NM[1] {
+    let input = readLine()!.split(separator: " ").map { Int($0)! }
+    let a = input[0], b = input[1]
+    
+    if findParent(a) == findParent(b) {
+        print(i)
+        exit(0)
+    }
+    union(a, b)
+}
+
+print(0)
+
+

--- a/jekyun-park/week18/boj/b2623.swift
+++ b/jekyun-park/week18/boj/b2623.swift
@@ -1,0 +1,80 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/01.
+//  BOJ > 2623 > 음악프로그램
+
+import Foundation
+
+var N = 0, M = 0
+var edges = Array(repeating: Array(repeating: false, count: 1001), count: 1001)
+var indegree = Array(repeating: 0, count: 1001)
+
+struct Queue {
+    var queue = [Int]()
+    var front = 0
+
+    var isEmpty: Bool {
+        return front >= queue.count
+    }
+
+    mutating func insert(_ n: Int) {
+        queue.append(n)
+    }
+
+    mutating func popFirst() -> Int {
+        let result = queue[front]
+        front += 1
+        return result
+    }
+}
+
+func topologySort() -> [Int] {
+    var result: [Int] = []
+    var queue = Queue()
+
+    for i in 1...N {
+        if indegree[i] == 0 {
+            queue.insert(i)
+        }
+    }
+
+    while !queue.isEmpty {
+        let current = queue.popFirst()
+
+        result.append(current)
+
+        for end in 1...N {
+            if edges[current][end] {
+                indegree[end] -= 1
+                if indegree[end] == 0 { queue.insert(end) }
+            }
+        }
+    }
+
+    if result.count != N { return [0] }
+    else { return result }
+}
+
+var input = readLine()!.split(separator: " ").map { Int($0)! }
+N = input[0]
+M = input[1]
+
+for _ in 0..<M {
+    input = readLine()!.split(separator: " ").map { Int($0)! }
+    for i in 1..<input.count - 1 {
+        let start = input[i]
+        let end = input[i + 1]
+
+        if !edges[start][end] {
+            edges[start][end] = true
+            indegree[end] += 1
+        }
+    }
+}
+
+let result = topologySort()
+print(result)
+result.forEach { print($0) }
+

--- a/jekyun-park/week18/programmers/84512.swift
+++ b/jekyun-park/week18/programmers/84512.swift
@@ -1,0 +1,41 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/04/29.
+//  Programmers > 위클리 챌린지 > 모음사전
+
+import Foundation
+
+func solution(_ word:String) -> Int {
+    
+    var answer = 0
+    let dictionary: [String:Int] = ["A":0,"E":1,"I":2,"O":3,"U":4]
+    let countArray = [781,156,31,6,1]
+    
+    answer = word.enumerated().map { countArray[$0.offset] * dictionary[String($0.element)]! }.reduce(word.count) { $0 + $1 }
+    
+    /*
+     index 0 1 2 3 4
+     
+     A
+     AA
+     AAA
+     AAAA
+     AAAAA
+     AAAAE
+     AAAAI
+     AAAAO
+     AAAAU
+     AAAE
+     AAAEA
+     AAAEE
+     AAAEI
+     AAAEO
+     AAAEU
+     AAAI
+     
+     */
+    
+    return answer
+}

--- a/jekyun-park/week18/programmers/86971.swift
+++ b/jekyun-park/week18/programmers/86971.swift
@@ -1,0 +1,58 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/04/26.
+//  Programmers > 위클리 챌린지 > 전력망을 둘로 나누기
+
+import Foundation
+
+func solution(_ n: Int, _ wires: [[Int]]) -> Int {
+
+    var network: [Int: [Int]] = [:]
+
+    for wire in wires {
+        network[wire[0], default: []].append(wire[1])
+        network[wire[1], default: []].append(wire[0])
+    }
+
+    var visited: [Bool] = Array(repeating: false, count: n + 1)
+    
+    func bfs(_ start: Int) -> Int {
+        var bfsQueue: [Int] = [start]
+        
+        var idx = 0
+        
+        while idx < bfsQueue.count {
+            let poped = bfsQueue[idx]
+            idx += 1
+            visited[poped] = true
+            
+            for number in network[poped]! {
+                if !visited[number] {
+                    bfsQueue.append(number)
+                }
+            }
+        }
+        
+        return idx
+    }
+    
+    visited[1] = true
+    let count = bfs(2)
+    var answer = abs(count-(n-count))
+    
+    for i in 1...n {
+        visited = Array(repeating: false, count: n + 1)
+        visited[i] = true
+        let count = bfs(1)
+        answer = min(answer, abs(count-(n-count)))
+    }
+    
+    return answer
+}
+
+
+print(solution(9, [[1, 3], [2, 3], [3, 4], [4, 5], [4, 6], [4, 7], [7, 8], [7, 9]]))
+print(solution(4, [[1,2],[2,3],[3,4]]))
+print(solution(7, [[1,2],[2,7],[3,7],[3,4],[4,5],[6,7]]))


### PR DESCRIPTION
## 프로그래머스 - 모음사전
**걸린 시간**
1시간, 검색
### 아이디어
구현
### 풀이방법
인덱스별로 다음 모음으로 이동하는데 필요한 단어의 수를 배열에 저장해놓는다.
단어의 인덱스별로 모음의 순서와 인덱스별 카운트를 곱해서 모두 더하면 답이 된다.

---

## 프로그래머스 - 전력망을 둘로 나누기
**걸린 시간**
30분
### 아이디어
bfs
### 풀이방법
전선은 트리 구조이므로 visited에 이미 방문했다는 표시를 하면 전선을 끊는것을 의미한다. visited를 초기화 하면서 하나씩 전선을 끊어보고, 이후 bfs탐색을 한다.
양쪽 전력망의 송전탑 개수 차이를 갱신한다.

---

## BOJ - 10775 공항
**걸린 시간**
1시간, 검색
### 아이디어
union find
### 풀이방법
번호가 들어오면 그 번호에 해당하는 부모를 찾는다.
부모를 바로 1 작은 번호에 이어준다. 만약 0이되면 종료한다.

---

## BOJ - 16938 캠프 준비
**걸린 시간**
15분
### 아이디어
조합
### 풀이방법
조합을 이용하여 2~N개까지 문제를 뽑아 조건에 맞으면 결과에 더해준다.

---

## BOJ - 20040 사이클 게임
**걸린 시간**
30분
### 아이디어
union find
### 풀이방법
두 점을 잇기 전에 같은 부모를 가지고 있는지 확인한다. 같은 부모를 갖고있다면 두 점을 이었을때 사이클이 생기므로 출력하고 아니라면 계속 진행한다.

---

## BOJ - 2623 음악프로그램
**걸린 시간**
1시간, 검색
### 아이디어
위상 정렬
### 풀이방법
각각의 보조 PD가 만든 순서를 받아서 그래프를 만들어주고, 진입차수를 설정해준다.
위상정렬을 진행한다. 결과에서 점의 개수가 N개가 아니면 순서를 정하는 것이 불가능한 경우이다.

---
