### PR TITLE
[20주차] 박제균

### DIFF
--- a/jekyun-park/week20/boj/b11437.swift
+++ b/jekyun-park/week20/boj/b11437.swift
@@ -1,0 +1,62 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/20.
+//  BOJ > 11437 > LCA(Lowest Common Ancestor)
+
+import Foundation
+
+
+let N = Int(readLine()!)!
+var tree = Array(repeating: [Int](), count: N + 1)
+var parent = Array(repeating: 0, count: N + 1)
+var depth = Array(repeating: 0, count: N + 1)
+var visited = Array(repeating: false, count: N + 1)
+
+for _ in 0..<N - 1 {
+    let uv = readLine()!.split(separator: " ").map { Int($0)! }
+    let u = uv.first!, v = uv.last!
+    tree[u].append(v)
+    tree[v].append(u)
+}
+
+func dfs(_ n: Int, _ d: Int) {
+    visited[n] = true
+    depth[n] = d
+
+    for node in tree[n] {
+        if visited[node] {
+            continue
+        }
+        parent[node] = n
+        dfs(node, d + 1)
+    }
+}
+
+func lca(_ a: inout Int, _ b: inout Int) -> Int {
+
+    while depth[a] != depth[b] {
+        if depth[a] > depth[b] {
+            a = parent[a]
+        } else {
+            b = parent[b]
+        }
+    }
+
+    while a != b {
+        a = parent[a]
+        b = parent[b]
+    }
+
+    return a
+}
+
+dfs(1, 0)
+
+let M = Int(readLine()!)!
+for _ in 0..<M {
+    let uv = readLine()!.split(separator: " ").map { Int($0)! }
+    var u = uv.first!, v = uv.last!
+    print(lca(&u, &v))
+}

--- a/jekyun-park/week20/boj/b15681.swift
+++ b/jekyun-park/week20/boj/b15681.swift
@@ -1,0 +1,38 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/20.
+//  BOJ > 15681 > 트리와 쿼리
+
+import Foundation
+
+let inputs = readLine()!.split(separator: " ").map { Int($0)! }
+let N = inputs[0], R = inputs[1], Q = inputs[2]
+
+
+func countNodes(_ n: Int) {
+    count[n] = 1
+    for i in tree[n] {
+        if count[i] == 0 {
+            countNodes(i)
+            count[n] += count[i]
+        }
+    }
+}
+var tree = Array(repeating: [Int](), count: N + 1)
+var count = Array(repeating: 0, count: N + 1)
+
+for _ in 0..<N - 1 {
+    let uv = readLine()!.split(separator: " ").map { Int($0)! }
+    let u = uv.first!, v = uv.last!
+    tree[u].append(v)
+    tree[v].append(u)
+}
+
+countNodes(R)
+
+for _ in 0..<Q {
+    let query = Int(readLine()!)!
+    print(count[query])
+}

--- a/jekyun-park/week20/boj/b2533.swift
+++ b/jekyun-park/week20/boj/b2533.swift
@@ -1,0 +1,37 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/20.
+//  BOJ > 2533 > 사회망 서비스
+
+import Foundation
+
+let N = Int(readLine()!)!
+
+var tree = Array(repeating: [Int](), count: N + 1)
+
+for _ in 0..<N - 1 {
+    let uv = readLine()!.split(separator: " ").map { Int($0)! }
+    let u = uv.first!, v = uv.last!
+    tree[u].append(v)
+    tree[v].append(u)
+}
+
+var dp = Array(repeating: [0, 0], count: N + 1)
+var visited = Array(repeating: false, count: N + 1)
+
+func dfs(_ n:Int) {
+    visited[n] = true
+    dp[n][0] = 1
+    for i in tree[n] {
+        if !visited[i] {
+            dfs(i)
+            dp[n][0] += min(dp[i][0], dp[i][1])
+            dp[n][1] += dp[i][0]
+        }
+    }
+}
+
+dfs(1)
+print(min(dp[1][0], dp[1][1]))

--- a/jekyun-park/week20/boj/b7682.swift
+++ b/jekyun-park/week20/boj/b7682.swift
@@ -1,0 +1,106 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/17.
+//  BOJ > 7682 > 틱택토
+
+import Foundation
+
+func checkBingo(_ map: [[String]], _ mark: String) -> Bool {
+    if map[0][0] == map[0][1] && map[0][1] == map[0][2] && map[0][2] == mark {
+        return true
+    }
+    if map[1][0] == map[1][1] && map[1][1] == map[1][2] && map[1][2] == mark {
+        return true
+    }
+    if map[2][0] == map[2][1] && map[2][1] == map[2][2] && map[2][2] == mark {
+        return true
+    }
+    if map[0][0] == map[1][0] && map[1][0] == map[2][0] && map[2][0] == mark {
+        return true
+    }
+    if map[0][1] == map[1][1] && map[1][1] == map[2][1] && map[2][1] == mark {
+        return true
+    }
+    if map[0][2] == map[1][2] && map[1][2] == map[2][2] && map[2][2] == mark {
+        return true
+    }
+    if map[0][0] == map[1][1] && map[1][1] == map[2][2] && map[2][2] == mark {
+        return true
+    }
+    if map[0][2] == map[1][1] && map[1][1] == map[2][0] && map[2][0] == mark {
+        return true
+    }
+    return false
+}
+
+
+var totalMap: [[String]] = []
+
+while true {
+    let input = readLine()!.map { String($0) }
+    if input == ["e", "n", "d"] {
+        break
+    }
+    totalMap.append(input)
+}
+
+for i in 0..<totalMap.count {
+
+    let game = totalMap[i]
+    var board = Array(repeating: Array(repeating: "", count: 3), count: 3)
+
+    var count = 0
+    var oCount = 0
+    var xCount = 0
+    var blankCount = 0
+
+    for i in 0..<3 {
+        for j in 0..<3 {
+            board[i][j] = game[count]
+            count += 1
+            if board[i][j] == "O" {
+                oCount += 1
+            } else if board[i][j] == "X" {
+                xCount += 1
+            } else {
+                blankCount += 1
+            }
+        }
+    }
+
+    if xCount > oCount + 1 {
+        print("invalid")
+        continue
+    }
+
+    if oCount > xCount {
+        print("invalid")
+        continue
+    }
+
+    if oCount == xCount {
+        if checkBingo(board, "O") && !checkBingo(board, "X") {
+            print("valid")
+            continue
+        }
+    }
+
+    if oCount + 1 == xCount {
+        if checkBingo(board, "X") && !checkBingo(board, "O") {
+            print("valid")
+            continue
+        }
+    }
+
+    if xCount == 5 && oCount == 4 {
+        if !checkBingo(board, "O") {
+            print("valid")
+            continue
+        }
+    }
+    
+    print("invalid")
+}
+

--- a/jekyun-park/week20/leetcode/leetcode200.swift
+++ b/jekyun-park/week20/leetcode/leetcode200.swift
@@ -1,0 +1,57 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/21.
+//  LeetCode 200. Number of Islands
+
+import Foundation
+
+class Solution {
+    let dx = [-1, 1, 0, 0]
+    let dy = [0, 0, -1, 1]
+    func numIslands(_ grid: [[Character]]) -> Int {
+
+        var grid = grid
+        var answer = 0
+        
+        for i in 0..<grid.count {
+            for j in 0..<grid[i].count {
+                if grid[i][j] == "1" {
+                    bfs(&grid, i, j)
+                    answer += 1
+                }
+            }
+        }
+
+        return answer
+    }
+
+    func bfs(_ grid: inout [[Character]], _ x: Int, _ y: Int) {
+        var queue: [(Int, Int)] = [(x,y)]
+        grid[x][y] = "0"
+        
+        var index = 0
+
+        while index < queue.count {
+
+            let r = queue[index].0
+            let c = queue[index].1
+
+            for i in 0..<4 {
+                let nx = r + dx[i]
+                let ny = c + dy[i]
+
+                if 0 > nx || nx >= grid.count || 0 > ny || ny >= grid[0].count { continue }
+                if grid[nx][ny] != "1" { continue }
+
+                grid[nx][ny] = "0"
+                queue.append((nx,ny))
+            }
+
+            index += 1
+        }
+        
+    }
+
+}

--- a/jekyun-park/week20/leetcode/leetcode56.swift
+++ b/jekyun-park/week20/leetcode/leetcode56.swift
@@ -1,0 +1,38 @@
+//
+//  main.swift
+//  SwiftAlgorithms
+//
+//  Created by 박제균 on 2022/05/22.
+//  LeetCode > 56. Merge Intervals
+
+import Foundation
+
+class Solution {
+    func merge(_ intervals: [[Int]]) -> [[Int]] {
+        if intervals.count < 1 { return intervals }
+        let intervals = intervals.sorted { $0[0] < $1[0] }
+        var answer: [[Int]] = [intervals[0]]
+
+        for i in 1..<intervals.count {
+
+            let interval = intervals[i]
+            let lastIndex = answer.count - 1
+
+            if overlap(answer[lastIndex], interval) {
+                answer[lastIndex] = [min(answer[lastIndex][0], interval[0]),max(answer[lastIndex][1], interval[1])]
+            } else {
+                answer.append(interval)
+            }
+        }
+
+        return answer
+    }
+
+    func overlap(_ a: [Int], _ b: [Int]) -> Bool {
+        return !(b[0] > a[1])
+    }
+
+}
+
+//let a = Solution()
+//print(a.merge([[1, 3], [2, 6], [8, 10], [15, 18]]))


### PR DESCRIPTION
## BOJ 7682 - 틱택토
**걸린 시간**
1시간 
### 아이디어
구현
### 풀이방법
빙고 경우의 수와, x와o의 수를 카운트해가면서 케이스별로 구현한다.

---

## BOJ 15681 - 트리와 쿼리
**걸린 시간**
1시간 이상 
### 아이디어
dfs
### 풀이방법
구글링 후 풀이참조...
각 정점을 루트로 하는 서브트리에 속한 정점의 수를 count에 담아주면서 dfs 탐색한다.

---

## BOJ 2533 - 사회망 서비스
**걸린 시간**
1시간 이상
### 아이디어
dfs+dp
### 풀이방법
구글링 후 풀이 참조
dp[i][0] 에는 i노드가 얼리어답터일 때 서브 트리에서 얼리어답터의 최소값
dp[i][1] 에는 i노드가 얼리어답터가 아닐 때 서브 트리에서 얼리어답터의 최소값 갱신

---

## BOJ 11437 - LCA
**걸린 시간**
1시간 이상
### 아이디어
LCA
### 풀이방법
LCA 알고리즘부터 찾아서 이해하고 다시 본 문제... 어려웠습니다

---

## LeetCode 200. Number of Islands
**걸린 시간**
20-30분
### 아이디어
bfs
### 풀이방법
기본적인 탐색 문제, 좌표마다 bfs 탐색하면서 1인곳을 0으로 바꿔주면서 중복해서 탐색하지 않도록 해준다.

---

## LeetCode 56. Merge Intervals
**걸린 시간**
25분
### 아이디어
정렬
### 풀이방법
전체 intervals를 시작범위 기준으로 정렬하고 범위가 겹치는지 여부를 판별한다.
겹친다면 새로 범위를 갱신해주고, 아니라면 배열에 집어넣는다.

---
